### PR TITLE
fix not-existing Floaterm wintype option

### DIFF
--- a/keys/which-key.vim
+++ b/keys/which-key.vim
@@ -230,7 +230,7 @@ let g:which_key_map.l = {
 " t is for terminal
 let g:which_key_map.t = {
       \ 'name' : '+terminal' ,
-      \ ';' : [':FloatermNew --wintype=popup --height=6'        , 'terminal'],
+      \ ';' : [':FloatermNew --wintype=normal --height=6'        , 'terminal'],
       \ 'f' : [':FloatermNew fzf'                               , 'fzf'],
       \ 'g' : [':FloatermNew lazygit'                           , 'git'],
       \ 'd' : [':FloatermNew lazydocker'                        , 'docker'],


### PR DESCRIPTION
Wintype type 'popup' is probably deprecated and no longer exists in Floaterm according to docs here:
https://github.com/voldikss/vim-floaterm/blob/master/doc/floaterm.txt
