### PR TITLE
dedup & (fix ?) keybindings.json

### DIFF
--- a/utils/vscode_config/keybindings.json
+++ b/utils/vscode_config/keybindings.json
@@ -1,13 +1,5 @@
 [
   {
-    "key": "shift+ctrl+e",
-    "command": "actions.findWithSelection"
-  },
-  {
-    "key": "ctrl+e",
-    "command": "-actions.findWithSelection"
-  },
-  {
     "key": "ctrl+e",
     "command": "workbench.view.explorer"
   },
@@ -59,11 +51,6 @@
     "key": "tab",
     "command": "workbench.action.quickOpenNavigateNext",
     "when": "inQuickOpen"
-  },
-  {
-    "key": "shit+tab",
-    "command": "selectPrevSuggestion",
-    "when": "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
   },
   {
     "key": "shift+tab",


### PR DESCRIPTION
## Deleted
Reason: Overrides `shift ctrl e` & `ctrl e`, which are defined right below the deleted portion
```
  {
    "key": "shift+ctrl+e",
    "command": "actions.findWithSelection"
  },
  {
    "key": "ctrl+e",
    "command": "-actions.findWithSelection"
  },
```

Reason: Duplicate
```
  {
    "key": "shit+tab",
    "command": "selectPrevSuggestion",
    "when": "editorTextFocus && suggestWidgetMultipleSuggestions && suggestWidgetVisible"
  },
```