### PR TITLE
Update keybindings.json

### DIFF
--- a/utils/vscode_config/keybindings.json
+++ b/utils/vscode_config/keybindings.json
@@ -219,4 +219,9 @@
     "key": "ctrl+shift+t",
     "command": "workbench.action.toggleMaximizedPanel"
   }
+  {
+    "key": "space",
+    "command": "whichkey.show",
+  },
+
 ]

--- a/utils/vscode_config/keybindings.json
+++ b/utils/vscode_config/keybindings.json
@@ -222,6 +222,7 @@
   {
     "key": "space",
     "command": "whichkey.show",
+    "when": "neovim.mode != 'insert'"
   },
 
 ]


### PR DESCRIPTION
Fix the error that vim which key doesn't work at welcome screen (or anything that doesn't open by Neovim backend). This error was mostly cause by the way the code is constructed (whichkey.show is handle inside Neovim, not vscode)