### PR TITLE
Change download URL of nvim appimage and change curl commandline args…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ bash <(curl -s https://raw.githubusercontent.com/ChristianChiarulli/nvim/master/
 - Ubuntu
 
   ```
-  curl -l https://github.com/neovim/neovim/releases/download/nightly/nvim.appimage > /tmp/nvim.appimage
+  curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage -o /tmp/nvim.appimage
 
   sudo mv /tmp/nvim.appimage /usr/local/bin/nvim
 


### PR DESCRIPTION
… to save properly.

Download URL seems to have changed since writing this.

Also on Ubuntu 20.04 using curl -o <outfile> properly writes file. curl > outfile just creates blank file.