### PR TITLE
Fix fzf-preview remote update

### DIFF
--- a/vim-plug/plugins.vim
+++ b/vim-plug/plugins.vim
@@ -59,7 +59,7 @@ call plug#begin('~/.config/nvim/autoload/plugged')
     Plug 'kevinhwang91/rnvimr'
     " FZF
     Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
-    Plug 'yuki-ycino/fzf-preview.vim', { 'branch': 'release', 'do': ':UpdateRemotePlugins' }
+    Plug 'yuki-ycino/fzf-preview.vim', { 'branch': 'release/remote', 'do': ':UpdateRemotePlugins' }
     Plug 'junegunn/fzf.vim'
     " Git
     Plug 'airblade/vim-gitgutter'


### PR DESCRIPTION
**Error**: `master branch doesn't exist`  

Fix update remote branch `release/remote`, 
according to the **fzf-preview** [Readme](https://github.com/yuki-yano/fzf-preview.vim/commit/985aaf0aec028f3469805ef17f7a3104905eff79#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)