### PR TITLE
Remove deprecated callback stuff.

### DIFF
--- a/lua/user/nvim-tree.lua
+++ b/lua/user/nvim-tree.lua
@@ -33,8 +33,6 @@ if not config_status_ok then
   return
 end
 
-local tree_cb = nvim_tree_config.nvim_tree_callback
-
 nvim_tree.setup {
   update_to_buf_dir = {
     enable = false,
@@ -96,9 +94,9 @@ nvim_tree.setup {
     mappings = {
       custom_only = false,
       list = {
-        { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
-        { key = "h", cb = tree_cb "close_node" },
-        { key = "v", cb = tree_cb "vsplit" },
+        { key = { "l", "<CR>", "o" }, action = "edit" },
+        { key = "h", action = "close_node" },
+        { key = "v", action = "vsplit" },
       },
     },
     number = false,


### PR DESCRIPTION
According to [nvim-tree's official docs](https://github.com/kyazdani42/nvim-tree.lua#settings), the cb = tree_cb stuff has been deprecated. These are the new equivalents.

Your Youtube channel has been a great help, thanks