### PR TITLE
fix: allow nvim to enter command-line window

### DIFF
--- a/lua/user/autocommands.lua
+++ b/lua/user/autocommands.lua
@@ -57,12 +57,6 @@ vim.api.nvim_create_autocmd({ "VimResized" }, {
   end,
 })
 
-vim.api.nvim_create_autocmd({ "CmdWinEnter" }, {
-  callback = function()
-    vim.cmd "quit"
-  end,
-})
-
 vim.api.nvim_create_autocmd({ "CursorMoved", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost" }, {
   callback = function()
     require("user.winbar").get_winbar()

--- a/lua/user/winbar.lua
+++ b/lua/user/winbar.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+M.winbar_buftype_exclude = {
+    "nofile"
+}
+
 M.winbar_filetype_exclude = {
   "help",
   "startify",
@@ -62,7 +66,7 @@ local get_gps = function()
 end
 
 local excludes = function()
-  if vim.tbl_contains(M.winbar_filetype_exclude, vim.bo.filetype) then
+  if vim.tbl_contains(M.winbar_filetype_exclude, vim.bo.filetype) or vim.tbl_contains(M.winbar_buftype_exclude, vim.bo.buftype) then
     vim.opt_local.winbar = nil
     return true
   end


### PR DESCRIPTION
Hello Chris,

I made a minor fix in my local config and I suspect this might be interesting to you so I'm submitting this PR.

With the autocommand in place it's impossible to enter command-line window and search / browser previous commands issued, like this:

![image](https://user-images.githubusercontent.com/29671981/172315391-d4736c48-560b-4b6c-95ee-8a7a48023540.png)



I suspect the purpose of that autocommand was to not create winbar in such window, so I created a buftype check and included "nofile" which also don't create the winbar.

We're now able to enter and browser the history of commands as in the print screen.



I hope this helps.

Thank you