### PR TITLE
fix: prevent winbar error on neovim 0.7

### DIFF
--- a/lua/user/autocommands.lua
+++ b/lua/user/autocommands.lua
@@ -63,11 +63,13 @@ vim.api.nvim_create_autocmd({ "CmdWinEnter" }, {
   end,
 })
 
-vim.api.nvim_create_autocmd({ "CursorMoved", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost" }, {
-  callback = function()
-    require("user.winbar").get_winbar()
-  end,
-})
+if vim.fn.has('nvim-0.8') == 1 then
+  vim.api.nvim_create_autocmd({ "CursorMoved", "BufWinEnter", "BufFilePost", "InsertEnter", "BufWritePost" }, {
+    callback = function()
+      require("user.winbar").get_winbar()
+    end,
+  })
+end
 
 vim.api.nvim_create_autocmd({ "BufWinEnter" }, {
   callback = function()


### PR DESCRIPTION
Hey Chris, I really appreciate all the work you're doing to educate people like myself on neovim.

This PR prevents the error described in #25 from occurring while running neovim stable (currently 0.7), since the winbar feature only works on nightly. I figure this could prevent a few headaches for anyone else running 0.7 instead of 0.8 while exploring this config.