### PR TITLE
Fixed disable automatic comment insertion

### DIFF
--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -59,7 +59,9 @@ end
 
 vim.cmd "set whichwrap+=<,>,[,],h,l"
 vim.cmd [[set iskeyword+=-]]
-vim.cmd [[set formatoptions-=cro]] -- TODO: this doesn't seem to work
+-- vim.cmd [[set formatoptions-=cro]] -- TODO: this doesn't seem to work
+vim.cmd [[autocmd FileType * setlocal formatoptions-=c formatoptions-=r formatoptions-=o]] -- this seem to work 
+
 
 vim.filetype.add {
   extension = {


### PR DESCRIPTION
Added disable automatic comment insertion while `:set formatoptions-=cro` not working. 

