### PR TITLE
LSP Inlay Hints: Fix ordering to match convention (client, bufnr)

### DIFF
--- a/lua/user/lsp-inlayhints.lua
+++ b/lua/user/lsp-inlayhints.lua
@@ -12,7 +12,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
     end
 
     local client = vim.lsp.get_client_by_id(args.data.client_id)
-    require("lsp-inlayhints").on_attach(args.buf, client)
+    require("lsp-inlayhints").on_attach(client, args.buf)
   end,
 })
 

--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -109,7 +109,7 @@ M.on_attach = function(client, bufnr)
   attach_navic(client, bufnr)
 
   if client.name == "tsserver" then
-    require("lsp-inlayhints").on_attach(bufnr, client)
+    require("lsp-inlayhints").on_attach(client, bufnr)
   end
 
   if client.name == "jdt.ls" then


### PR DESCRIPTION
Without this fix, a warning is raised:

```
[LSP Inlayhints] on_attach should be called with (client, bufnr)
```

This PR fixes it. Please also see the up-stream recent fix for context: https://github.com/lvimuser/lsp-inlayhints.nvim/commit/43179162f290c6eee9b229bb84c22028d2629bf4